### PR TITLE
Use after-resolvers to hook into resolvers to support webpack2

### DIFF
--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -27,17 +27,19 @@ WebpackRailsI18nJSPlugin.prototype.apply = function(compiler) {
     })
   })
 
-  compiler.resolvers.normal.plugin('module', function(request, callback) {
-    if(request.request === moduleName) {
-      callback(null, {
-        path: path.join(__dirname, '..', 'i18n', 'index.js'),
-        query: request.query,
-        file: true,
-        resolved: true
-      })
-    } else {
-      callback();
-    }
+  compiler.plugin("after-resolvers", function(compiler) {
+    compiler.resolvers.normal.plugin('module', function(request, callback) {
+      if(request.request === moduleName) {
+        callback(null, {
+          path: path.join(__dirname, '..', 'i18n', 'index.js'),
+          query: request.query,
+          file: true,
+          resolved: true
+        })
+      } else {
+        callback();
+      }
+    })
   })
 }
 


### PR DESCRIPTION
In Webpack 2 , Resolvers are created later in the process, so they're null in `apply`.
This makes the plugin works with Webpack 2 .