### PR TITLE
Fix issue where `compiler.resolvers.normal` is undefined

### DIFF
--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -27,18 +27,20 @@ WebpackRailsI18nJSPlugin.prototype.apply = function(compiler) {
     })
   })
 
-  compiler.resolvers.normal.plugin('module', function(request, callback) {
-    if(request.request === moduleName) {
-      callback(null, {
-        path: path.join(__dirname, '..', 'i18n', 'index.js'),
-        query: request.query,
-        file: true,
-        resolved: true
-      })
-    } else {
-      callback();
-    }
-  })
+  if (compiler.resolvers.normal) {
+    compiler.resolvers.normal.plugin('module', function(request, callback) {
+      if(request.request === moduleName) {
+        callback(null, {
+          path: path.join(__dirname, '..', 'i18n', 'index.js'),
+          query: request.query,
+          file: true,
+          resolved: true
+        })
+      } else {
+        callback();
+      }
+    })
+  }
 }
 
 module.exports = WebpackRailsI18nJSPlugin


### PR DESCRIPTION
I attempted to use this plugin with Webpack 2 as I have used it with version 1 in the past. In order to quiet an error where `normal` is undefined, I've added a conditional.